### PR TITLE
README: Fix missing step in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,25 +89,22 @@ known issues to report.
 
 ### Dependencies
 
-Our software has the following dependencies
+Our software has the following dependencies:
 ```
 clang-12
 llvm-12
 llvm-12-tools
 python3
+python3-pip
 make
 cmake
 libjsoncpp-dev
 libz3-dev
 ```
 
-It also depends on the following python packages:
+It also requires a few Python packages:
 ```
-packaging
-prettytable
-termcolor
-toml
-z3-solver
+pip install requirements.txt
 ```
 
 Finally, the `lib_reg_bounds_tracking` package must be installed from sources:

--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ toml
 z3-solver
 ```
 
+Finally, the `lib_reg_bounds_tracking` package must be installed from sources:
+```
+cd bpf-verification
+pip install .
+```
+
 --------------------------------------------------------------------------------
 
 ## (1.) Automatically extracting the semantics of the Linux kernel's C code to SMT (30 minutes)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+packaging
+prettytable
+termcolor
+toml
+z3-solver


### PR DESCRIPTION
The `lib_reg_bounds_tracking` package also needs to be installed before running verification.