### PR TITLE
.gitattributes: Ignore generated SMT files in GitHub statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+reproduce-results/bpf-encodings/ linguist-generated


### PR DESCRIPTION
SMT is currently detected as the main language when it should probably be Python or C++. This commit marks the SMT files as generated so that [Linguist](https://github.com/github-linguist/linguist) recomputes the statistics. It will only be visible a little bit after this is merged unfortunately.