### PR TITLE
.gitattributes: Fix syntax for directory

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-reproduce-results/bpf-encodings/ linguist-generated
+reproduce-results/bpf-encodings/** linguist-generated


### PR DESCRIPTION
The `.gitattributes` syntax for the Linguist override is incorrect. Selecting all in a directory requires `/**`. I got confused between the different syntaxes git and GitHub have for directories.

I tested it locally this time by installing Linguist:

    $ gem install github-linguist
    $ github-linguist
    57.00%  178040     Python
    37.30%  116499     C++
    2.89%   9037       Shell
    2.81%   8762       CMake

Fixes: 546421f31dea (".gitattributes: Ignore generated SMT files in GitHub statistics")