### PR TITLE
llvm-to-smt: Support llvm.*mul.with.overflow.* intrinsics

### DIFF
--- a/llvm-to-smt/llvm-passes/LLVMToSMT/FunctionEncoder.hpp
+++ b/llvm-to-smt/llvm-passes/LLVMToSMT/FunctionEncoder.hpp
@@ -160,7 +160,7 @@ public:
   void handleMemoryPhiNode(MemoryPhi &mphi, FunctionEncoderPassType passID);
   void handleCallInst(CallInst &i);
   void handleIntrinsicCallInst(IntrinsicInst &i);
-  void handleAddSubWithOverflowIntrinsic(IntrinsicInst &i);
+  void handleLLVMOverflowInstrinsics(IntrinsicInst &i);
   void handleGEPInstFromSelect(GetElementPtrInst &i);
   void handleGEPInstFromPHI(GetElementPtrInst &i);
   void handlePhiInstPointer(PHINode &inst);


### PR DESCRIPTION
This commits support for llvm mul intrinsics with overflow detection:  llvm.\*mul.with.overflow.\*. The details of the added support are similar to a240015.

The eventual idea is that we can individually verify at least some sub-functions of BPF_MUL: 
```
case BPF_MUL:
  tnum_mul(); 
  scalar32_min_max_mul();
  scalar_min_max_mul();
```

`tnum_mul()` has loops, and cannot be *automatically* verified (we have a written proof), but the other two can still be verified automatically.


