### PR TITLE
llvm-to-smt: remove same reg comparison from verifier.c

### DIFF
--- a/llvm-to-smt/cocci/remove_same_reg_comparison.cocci
+++ b/llvm-to-smt/cocci/remove_same_reg_comparison.cocci
@@ -1,0 +1,20 @@
+@remove_same_reg_branch@
+identifier fn = is_scalar_branch_taken;
+@@
+
+fn(...) {
+<...
+-	if (reg1 == reg2) { ... }
+...>
+}
+
+@remove_same_reg_skip_refine@
+identifier fn = reg_set_min_max;
+@@
+
+fn(...) {
+<...
+-	if (false_reg1 == false_reg2)
+-		return 0;
+...>
+}

--- a/llvm-to-smt/generate_encodings.py
+++ b/llvm-to-smt/generate_encodings.py
@@ -569,6 +569,14 @@ def reg_bounds_sync_calls_remove(verifier_c_filepath, logfile, logfile_err):
                    check=True, text=True, bufsize=1)
 
 
+def same_reg_comparison_remove(verifier_c_filepath, logfile, logfile_err):
+    spatch_fullpath = cocci_fullpath.joinpath('remove_same_reg_comparison.cocci')
+    cmd_checkout = ['spatch', '--very-quiet', '--in-place', '{}'.format(verifier_c_filepath), '--sp-file', '{}'.format(spatch_fullpath)]
+    print(" ".join(cmd_checkout))
+    subprocess.run(cmd_checkout, stdout=logfile, stderr=logfile_err,
+                   check=True, text=True, bufsize=1)
+
+
 def reg_bounds_sanity_check_calls_remove(verifier_c_filepath):
     inputfile_handle = verifier_c_filepath.open("r")
     input_file_lines = inputfile_handle.readlines()
@@ -854,6 +862,7 @@ if __name__ == "__main__":
     if args.modular:
         reg_bounds_sync_calls_remove(verifier_file_path, logfile, logfile_err)
         reg_bounds_sanity_check_calls_remove(verifier_file_path)
+    same_reg_comparison_remove(verifier_file_path, logfile, logfile_err)
     insert_sync_wrapper(verifier_file_path, args.kernver)
     print_and_log(" ... done")
 


### PR DESCRIPTION
Commit [d43ad9da8](https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git/commit/?id=d43ad9da8052eda714ca) upstream causes llvm-to-smt to fail, because it causes clang to emit code that checks whether two pointers are equal.

The corresponding C code snippet is from `is_scalar_branch_taken()` in verifier.c. This function accepts two `bpf_reg_state` pointers. The upstream commit d43ad9da8 adds a check to see if they are equal.

```
static int is_scalar_branch_taken(struct bpf_reg_state *reg1, struct bpf_reg_state *reg2,
				  u8 opcode, bool is_jmp32) {
    ...

    if (reg1 == reg2) {
        ...
        // exit early with return 0 or 1
    }
}
```

The commit was introduced to address the case where the jump condition actually compares the register to itself, e.g.  if `r0 > r0`. This causes clang to emit an icmp on pointers, not something that llvm-to-smt can support:

```
%cmp1 = icmp eq %struct.bpf_reg_state* %reg1, %reg2
```

In Agni, we assume the inputs to the verifier functions (e.g. `dst_reg` and `src_reg` pointers) are disjoint and never alias. So a check like `dst_reg == src_reg` is not meaningful in the context of our memory model.

Agni is meant for detecting logic errors in the updating of the `bpf_reg_state` bounds, that happens only when the `dst_reg` and `src_reg` pointers are distinct.

All of that to say, we can safely "undo" the upstream commit and ensure that llvm-to-smt continues to work.