### PR TITLE
workflows: Fix warning on condition

### DIFF
--- a/.github/workflows/bpf-verification.yaml
+++ b/.github/workflows/bpf-verification.yaml
@@ -52,7 +52,7 @@ jobs:
             --ver_set ${{ matrix.insn }}
 
       - name: Upload artifacts
-        if: ${{ always() }} && steps.bpf-verification.outcome != 'skipped'
+        if: ${{ always() && steps.bpf-verification.outcome != 'skipped' }}
         uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
         with:
           name: results-${{ matrix.kernel }}-${{ matrix.insn }}-${{ matrix.spec }}

--- a/.github/workflows/end-to-end.yaml
+++ b/.github/workflows/end-to-end.yaml
@@ -132,7 +132,7 @@ jobs:
           fi
 
       - name: Upload encodings
-        if: ${{ always() }} && steps.generate-encodings.outcome != 'skipped'
+        if: ${{ always() && steps.generate-encodings.outcome != 'skipped' }}
         uses: actions/upload-artifact@master
         with:
           name: bpf-encodings-${{ matrix.tree }}-${{ matrix.insn }}
@@ -158,7 +158,7 @@ jobs:
           fi
 
       - name: Upload results
-        if: ${{ always() }} && steps.bpf-verification.outcome != 'skipped'
+        if: ${{ always() && steps.bpf-verification.outcome != 'skipped' }}
         uses: actions/upload-artifact@master
         with:
           name: results-${{ matrix.tree }}-${{ matrix.insn }}

--- a/.github/workflows/llvm-to-smt.yml
+++ b/.github/workflows/llvm-to-smt.yml
@@ -111,7 +111,7 @@ jobs:
           fi
 
       - name: Upload artifacts
-        if: ${{ always() }} && steps.generate-encodings.outcome != 'skipped'
+        if: ${{ always() && steps.generate-encodings.outcome != 'skipped' }}
         uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
         with:
           name: bpf-encodings-${{ matrix.kernel }}-${{ matrix.insn }}


### PR DESCRIPTION
GitHub is complaining with the following warning:

  .github/workflows/end-to-end.yaml (Line: 145, Col: 13): Conditional
  expression contains literal text outside replacement tokens. This
  will cause the expression to always evaluate to truthy. Did you mean
  to put the entire expression inside ${{ }}?

This commit fixes it.

Fixes: cbf069d9 ("workflows: Collect artifacts regardless of failures")